### PR TITLE
Upgrade to SSHD 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
   	  <groupId>net.i2p.crypto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <revision>3.1.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.282</jenkins.version> <!-- Current weekly -->
+    <jenkins.version>2.289.1</jenkins.version> <!-- Current weekly -->
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </licenses>
 
   <properties>
-    <revision>3.0.5</revision>
+    <revision>3.1.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.282</jenkins.version> <!-- Current weekly -->
     <java.level>8</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>2.7.0</version>
+      <version>2.6.0</version>
     </dependency>
     <dependency>
   	  <groupId>net.i2p.crypto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>2.7.0-SNAPSHOT</version>
+      <version>2.6.0</version>
     </dependency>
     <dependency>
   	  <groupId>net.i2p.crypto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0-SNAPSHOT</version>
     </dependency>
     <dependency>
   	  <groupId>net.i2p.crypto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <revision>3.1.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.289.1</jenkins.version> <!-- Current weekly -->
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
@@ -126,7 +126,8 @@ public abstract class AsynchronousCommand implements Command, ServerSessionAware
             PrintWriter ps = new PrintWriter(new OutputStreamWriter(err, Charset.defaultCharset()));
             e.printStackTrace(ps);
             ps.flush();
-
+            out.flush(); // working around SSHD-154
+            err.flush();
             callback.onExit(255,e.getMessage());
         }
     }

--- a/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
@@ -3,14 +3,15 @@ package org.jenkinsci.main.modules.sshd;
 import hudson.model.User;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
-import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
-import org.apache.sshd.server.SessionAware;
 import org.apache.sshd.server.session.ServerSession;
+import org.apache.sshd.server.session.ServerSessionAware;
 import org.jenkinsci.main.modules.sshd.SshCommandFactory.CommandLine;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,8 +20,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 
-import org.acegisecurity.context.SecurityContext;
-
 import javax.annotation.CheckForNull;
 
 /**
@@ -28,7 +27,7 @@ import javax.annotation.CheckForNull;
  *
  * @author Kohsuke Kawaguchi
  */
-public abstract class AsynchronousCommand implements Command, SessionAware, Runnable {
+public abstract class AsynchronousCommand implements Command, ServerSessionAware, Runnable {
     private InputStream in;
     private OutputStream out;
     private OutputStream err;
@@ -117,7 +116,7 @@ public abstract class AsynchronousCommand implements Command, SessionAware, Runn
             SecurityContext old = SecurityContextHolder.getContext();
             User user = getCurrentUser();
             if (user!=null)
-                ACL.impersonate(user.impersonate());
+                ACL.as(user);
 
             try {
                 i = AsynchronousCommand.this.runCommand();

--- a/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
@@ -110,8 +110,8 @@ public abstract class AsynchronousCommand implements Command, ServerSessionAware
         try {
             int i;
             User user = getCurrentUser();
-            if(user!=null){
-              try(ACLContext ctx = ACL.as(user)){
+            if (user != null) {
+              try (ACLContext ctx = ACL.as(user)) {
                 i = AsynchronousCommand.this.runCommand();
               }
             } else {

--- a/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
@@ -2,6 +2,7 @@ package org.jenkinsci.main.modules.sshd;
 
 import hudson.model.User;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import jenkins.model.Jenkins;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;

--- a/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
@@ -10,8 +10,6 @@ import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.server.session.ServerSessionAware;
 import org.jenkinsci.main.modules.sshd.SshCommandFactory.CommandLine;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
@@ -118,8 +118,7 @@ public abstract class AsynchronousCommand implements Command, ServerSessionAware
             } else {
               i = AsynchronousCommand.this.runCommand();
             }
-            out.flush(); // working around SSHD-154
-            err.flush();
+            flushOutputs();
             callback.onExit(i);
         } catch (Exception e) {
             // report the cause of the death to the client
@@ -127,9 +126,20 @@ public abstract class AsynchronousCommand implements Command, ServerSessionAware
             PrintWriter ps = new PrintWriter(new OutputStreamWriter(err, Charset.defaultCharset()));
             e.printStackTrace(ps);
             ps.flush();
-            out.flush(); // working around SSHD-154
-            err.flush();
+            flushOutputs();
             callback.onExit(255,e.getMessage());
+        }
+    }
+
+    /**
+     *  working around SSHD-154
+     */
+    private void flushOutputs() {
+        try {
+            out.flush();
+            err.flush();
+        } catch (IOException ioException) {
+           //NOOP
         }
     }
 

--- a/src/main/java/org/jenkinsci/main/modules/sshd/IdleTimeout.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/IdleTimeout.java
@@ -1,7 +1,8 @@
 package org.jenkinsci.main.modules.sshd;
 
-import org.apache.sshd.server.ServerFactoryManager;
+import org.apache.sshd.core.CoreModuleProperties;
 import org.apache.sshd.server.SshServer;
+import java.time.Duration;
 import java.util.logging.Logger;
 
 import org.kohsuke.accmod.Restricted;
@@ -15,6 +16,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public class IdleTimeout {
 
 	private static final Logger LOGGER = Logger.getLogger(IdleTimeout.class.getName());
+	public static final long ADDITIONAL_TIME_FOR_TIMEOUT = 60000;
 
 	private final Long timeoutInMilliseconds;
 
@@ -42,13 +44,13 @@ public class IdleTimeout {
 			return;
 		}
 
-		sshd.getProperties().put(ServerFactoryManager.IDLE_TIMEOUT, timeoutInMilliseconds);
+		CoreModuleProperties.IDLE_TIMEOUT.set(sshd, Duration.ofMillis(timeoutInMilliseconds));
 		// Read timeout must also be changed
 		long readTimeout = 0;
 		if (timeoutInMilliseconds != 0) {
-			readTimeout = ServerFactoryManager.DEFAULT_NIO2_READ_TIMEOUT - ServerFactoryManager.DEFAULT_IDLE_TIMEOUT + timeoutInMilliseconds;
+			readTimeout = ADDITIONAL_TIME_FOR_TIMEOUT + timeoutInMilliseconds;
 		}
-		sshd.getProperties().put(ServerFactoryManager.NIO2_READ_TIMEOUT, readTimeout);
+		CoreModuleProperties.NIO2_READ_TIMEOUT.set(sshd, Duration.ofSeconds(readTimeout));
 	}
 
 }

--- a/src/test/java/org/jenkinsci/main/modules/sshd/IdleTimeoutTest.java
+++ b/src/test/java/org/jenkinsci/main/modules/sshd/IdleTimeoutTest.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.main.modules.sshd;
 
 
-import org.apache.sshd.server.ServerFactoryManager;
+import org.apache.sshd.core.CoreModuleProperties;
 import org.apache.sshd.server.SshServer;
 import org.junit.Assert;
 import org.junit.Before;
@@ -29,8 +29,8 @@ public class IdleTimeoutTest {
 		idleTimeout.apply(sshd);
 
 		Map<String, Object> properties = sshd.getProperties();
-		Assert.assertFalse(properties.containsKey(ServerFactoryManager.IDLE_TIMEOUT));
-		Assert.assertFalse(properties.containsKey(ServerFactoryManager.NIO2_READ_TIMEOUT));
+		Assert.assertFalse(properties.containsKey(CoreModuleProperties.IDLE_TIMEOUT.getName()));
+		Assert.assertFalse(properties.containsKey(CoreModuleProperties.NIO2_READ_TIMEOUT.getName()));
 	}
 
 	@Test
@@ -40,10 +40,8 @@ public class IdleTimeoutTest {
 
 		idleTimeout.apply(sshd);
 
-		Map<String, Object> properties = sshd.getProperties();
-		Assert.assertEquals(timeoutInMilliseconds, properties.get(ServerFactoryManager.IDLE_TIMEOUT));
-		Object readTimeout = properties.get(ServerFactoryManager.NIO2_READ_TIMEOUT);
-		Assert.assertTrue(readTimeout instanceof Long);
+		Assert.assertEquals(timeoutInMilliseconds, CoreModuleProperties.IDLE_TIMEOUT.get(sshd).get().toMillis());
+		Long readTimeout = CoreModuleProperties.NIO2_READ_TIMEOUT.get(sshd).get().toMillis();
 		Assert.assertTrue((Long) readTimeout > timeoutInMilliseconds);
 	}
 
@@ -54,8 +52,8 @@ public class IdleTimeoutTest {
 		idleTimeout.apply(sshd);
 
 		Map<String, Object> properties = sshd.getProperties();
-		Assert.assertFalse(properties.containsKey(ServerFactoryManager.IDLE_TIMEOUT));
-		Assert.assertFalse(properties.containsKey(ServerFactoryManager.NIO2_READ_TIMEOUT));
+		Assert.assertFalse(properties.containsKey(CoreModuleProperties.IDLE_TIMEOUT.getName()));
+		Assert.assertFalse(properties.containsKey(CoreModuleProperties.NIO2_READ_TIMEOUT.getName()));
 	}
 
 }


### PR DESCRIPTION
see [JENKINS-60902](https://issues.jenkins-ci.org/browse/JENKINS-60902)

It bumps the [Apache Mina sshd](https://github.com/apache/mina-sshd) library to 2.7.0

it replaces https://github.com/jenkinsci/sshd-module/pull/33
it depends on [JENKINS-55582](https://issues.jenkins-ci.org/browse/JENKINS-55582)

This PR is the same change in https://github.com/jenkinsci/sshd-plugin/pull/37 but implement AsynchronousCommand as runnable due to some changes in the Apache Mina library, this requires changes on other plugins because of signature changes. The change is to rename the method `run` to `runCommand`.