### PR TITLE
Remove JSR 305

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/UserPropertyImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/cli/auth/ssh/UserPropertyImpl.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.main.modules.cli.auth.ssh;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
@@ -52,6 +53,7 @@ public class UserPropertyImpl extends UserProperty {
     @Extension
     @Symbol("sshPublicKey")
     public static final class DescriptorImpl extends UserPropertyDescriptor {
+        @NonNull
         public String getDisplayName() {
             return "SSH Public Keys";
         }

--- a/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/AsynchronousCommand.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.main.modules.sshd;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -18,8 +19,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
-
-import javax.annotation.CheckForNull;
 
 /**
  * Partial {@link Command} implementation that uses a thread to run a command.

--- a/src/main/java/org/jenkinsci/main/modules/sshd/PortAdvertiser.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PortAdvertiser.java
@@ -1,10 +1,10 @@
 package org.jenkinsci.main.modules.sshd;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.PageDecorator;
 import jenkins.model.Jenkins;
 
-import javax.annotation.CheckForNull;
 import javax.inject.Inject;
 import java.net.URL;
 import java.util.logging.Level;

--- a/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/PublicKeyAuthenticatorImpl.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.main.modules.sshd;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.User;
 import jenkins.security.SecurityListener;
 import org.acegisecurity.AuthenticationException;
@@ -10,8 +12,6 @@ import org.apache.sshd.server.session.ServerSession;
 import org.jenkinsci.main.modules.cli.auth.ssh.PublicKeySignatureWriter;
 import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import java.security.PublicKey;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -67,7 +67,7 @@ class PublicKeyAuthenticatorImpl implements PublickeyAuthenticator {
         return u;
     }
 
-    private @CheckForNull UserDetails verifyUserUsingSecurityRealm(@Nonnull User user) {
+    private @CheckForNull UserDetails verifyUserUsingSecurityRealm(@NonNull User user) {
         try {
             return user.getUserDetailsForImpersonation();
         } catch (UsernameNotFoundException e) {

--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.main.modules.sshd;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.init.InitMilestone;
@@ -15,7 +16,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForSigned;
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
 
@@ -65,6 +65,7 @@ public class SSHD extends GlobalConfiguration {
     private static final String EXCLUDED_MACS = SystemProperties.getString(SSHD.class.getName() + ".excludedMacs",
             "hmac-md5, hmac-md5-96, hmac-sha1-96");
 
+    @NonNull
     @Override
     public GlobalConfigurationCategory getCategory() {
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
@@ -126,7 +127,7 @@ public class SSHD extends GlobalConfiguration {
      * Cyphers will be considered as activated if they are defined in {@link #ENABLED_CIPHERS} and supported in the current JVM.
      * @return List of factories
      */
-    @Nonnull
+    @NonNull
     /*package*/ static List<NamedFactory<Cipher>> getActivatedCiphers() {
         final List<NamedFactory<Cipher>> activatedCiphers = new ArrayList<>(ENABLED_CIPHERS.size());
         for (NamedFactory<Cipher> cipher : ENABLED_CIPHERS) {


### PR DESCRIPTION
Removes JSR 305 and adds missing annotations.

There are still two types left:

- javax.annotation.CheckForSigned
- javax.annotation.concurrent.GuardedBy

Is there any suitable replacement?

/cc @basil


--------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
