### PR TITLE
Stop bundling SLF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
-    <slf4j.version>1.7.36</slf4j.version>
   </properties>
 
   <dependencyManagement>
@@ -45,16 +44,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -63,6 +52,17 @@
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
       <version>2.8.0</version>
+      <exclusions>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
   	  <groupId>net.i2p.crypto</groupId>


### PR DESCRIPTION
This plugin bundles `slf4j-api-1.7.36.jar` and `jcl-over-slf4j-1.7.36.jar`:

```
[INFO] Assembling webapp sshd in src/jenkinsci/sshd-plugin/target/sshd
[WARNING] Bundling transitive dependency self-signed-cert-generator-1.0.0.jar (via instance-identity)
[INFO] Bundling direct dependency eddsa-0.3.0.jar
[WARNING] Bundling transitive dependency sshd-common-2.8.0.jar (via sshd-core)
[INFO] Bundling direct dependency sshd-core-2.8.0.jar
[INFO] Bundling direct dependency instance-identity-2.2.jar
[WARNING] Bundling transitive dependency jcl-over-slf4j-1.7.36.jar (via sshd-core)
[WARNING] Bundling transitive dependency slf4j-api-1.7.36.jar (via sshd-core)
[INFO] Generating hpi src/jenkinsci/sshd-plugin/target/sshd.hpi
[INFO] Building jar: src/jenkinsci/sshd-plugin/target/sshd.hpi
```

This is incorrect as the JAR is already bundled in core, and the details of plugin classloading means that core's copy will always be used rather than that bundled in the plugin. This [causes an Enforcer error in the plugin BOM](https://ci.jenkins.io/job/Tools/job/bom/job/PR-993/1/console) in https://github.com/jenkinsci/bom/pull/993:


```
[INFO] --- maven-enforcer-plugin:3.0.0:enforce (display-info) @ sample ---
[INFO] Adding ignore: module-info
[INFO] Ignoring requireUpperBoundDeps in org.kohsuke:access-modifier-annotation
[INFO] Ignoring requireUpperBoundDeps in com.github.spotbugs:spotbugs-annotations
[INFO] Ignoring requireUpperBoundDeps in javax.servlet:servlet-api
[WARNING] Rule 5: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.slf4j:slf4j-api:1.7.31 [provided] paths to dependency are:
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.plugins:support-core:2.80 [test]
    +-net.sf.uadetector:uadetector-resources:2014.10 [test]
      +-org.slf4j:slf4j-api:1.7.31 [provided] (managed) <-- org.slf4j:slf4j-api:1.7.7 [provided]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.main:jenkins-core:2.303.3 [provided]
    +-org.slf4j:jcl-over-slf4j:1.7.31 [provided] (managed) <-- org.slf4j:jcl-over-slf4j:1.7.31 [provided]
      +-org.slf4j:slf4j-api:1.7.31 [provided] (managed) <-- org.slf4j:slf4j-api:1.7.31 [provided]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.main:jenkins-core:2.303.3 [provided]
    +-org.slf4j:log4j-over-slf4j:1.7.31 [provided] (managed) <-- org.slf4j:log4j-over-slf4j:1.7.31 [provided]
      +-org.slf4j:slf4j-api:1.7.31 [provided] (managed) <-- org.slf4j:slf4j-api:1.7.31 [provided]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.main:jenkins-war:2.303.3 [test]
    +-org.slf4j:slf4j-jdk14:1.7.31 [test] (managed) <-- org.slf4j:slf4j-jdk14:1.7.31 [test]
      +-org.slf4j:slf4j-api:1.7.31 [test] (managed) <-- org.slf4j:slf4j-api:1.7.31 [test]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.plugins:ldap:2.8 [test]
    +-org.springframework.security:spring-security-ldap:5.5.1 [test] (managed) <-- org.springframework.security:spring-security-ldap:5.4.4 [test]
      +-org.springframework.ldap:spring-ldap-core:2.3.4.RELEASE [test]
        +-org.slf4j:slf4j-api:1.7.31 [test] (managed) <-- org.slf4j:slf4j-api:1.7.21 [test]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.plugins:support-core:2.80 [test]
    +-net.sf.uadetector:uadetector-resources:2014.10 [test]
      +-net.sf.uadetector:uadetector-core:0.9.22 [test]
        +-org.slf4j:slf4j-api:1.7.31 [test] (managed) <-- org.slf4j:slf4j-api:1.7.7 [test]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.plugins.workflow:workflow-cps-global-lib:564.ve62a_4eb_b_e039 [test]
    +-org.jenkins-ci.plugins:git-server:1.10 [test] (managed) <-- org.jenkins-ci.plugins:git-server:1.10 [test]
      +-org.jenkins-ci.modules:sshd:3.226.vb_1769a_7fb_b_a_6 [test] (managed) <-- org.jenkins-ci.modules:sshd:3.0.4 [test]
        +-org.apache.sshd:sshd-core:2.8.0 [test]
          +-org.slf4j:slf4j-api:1.7.31 [test] (managed) <-- org.slf4j:slf4j-api:1.7.32 [test]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.plugins.workflow:workflow-cps-global-lib:564.ve62a_4eb_b_e039 [test]
    +-org.jenkins-ci.plugins:git-server:1.10 [test] (managed) <-- org.jenkins-ci.plugins:git-server:1.10 [test]
      +-org.jenkins-ci.modules:sshd:3.226.vb_1769a_7fb_b_a_6 [test] (managed) <-- org.jenkins-ci.modules:sshd:3.0.4 [test]
        +-org.apache.sshd:sshd-core:2.8.0 [test]
          +-org.apache.sshd:sshd-common:2.8.0 [test]
            +-org.slf4j:slf4j-api:1.7.31 [test] (managed) <-- org.slf4j:slf4j-api:1.7.32 [test]
, 
Require upper bound dependencies error for org.slf4j:jcl-over-slf4j:1.7.31 [provided] paths to dependency are:
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.main:jenkins-core:2.303.3 [provided]
    +-org.slf4j:jcl-over-slf4j:1.7.31 [provided] (managed) <-- org.slf4j:jcl-over-slf4j:1.7.31 [provided]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.plugins.workflow:workflow-cps-global-lib:564.ve62a_4eb_b_e039 [test]
    +-org.jenkins-ci.plugins:git-server:1.10 [test] (managed) <-- org.jenkins-ci.plugins:git-server:1.10 [test]
      +-org.jenkins-ci.modules:sshd:3.226.vb_1769a_7fb_b_a_6 [test] (managed) <-- org.jenkins-ci.modules:sshd:3.0.4 [test]
        +-org.apache.sshd:sshd-core:2.8.0 [test]
          +-org.slf4j:jcl-over-slf4j:1.7.31 [test] (managed) <-- org.slf4j:jcl-over-slf4j:1.7.32 [test]
and
+-io.jenkins.tools.bom:sample:1259.v3a_7fc8ff4f87
  +-org.jenkins-ci.plugins.workflow:workflow-cps-global-lib:564.ve62a_4eb_b_e039 [test]
    +-org.jenkins-ci.plugins:git-server:1.10 [test] (managed) <-- org.jenkins-ci.plugins:git-server:1.10 [test]
      +-org.jenkins-ci.modules:sshd:3.226.vb_1769a_7fb_b_a_6 [test] (managed) <-- org.jenkins-ci.modules:sshd:3.0.4 [test]
        +-org.apache.sshd:sshd-core:2.8.0 [test]
          +-org.apache.sshd:sshd-common:2.8.0 [test]
            +-org.slf4j:jcl-over-slf4j:1.7.31 [test] (managed) <-- org.slf4j:jcl-over-slf4j:1.7.32 [test]
]
```

This PR corrects the problem by not bundling the unnecessary JAR.

The plugin now only bundles:

```
[INFO] --- maven-hpi-plugin:3.27:hpi (default-hpi) @ sshd ---
[INFO] Generating src/jenkinsci/sshd-plugin/target/sshd/META-INF/MANIFEST.MF
[INFO] Checking for attached .jar artifact ...
[INFO] Generating jar src/jenkinsci/sshd-plugin/target/sshd.jar
[INFO] Building jar: src/jenkinsci/sshd-plugin/target/sshd.jar
[INFO] Exploding webapp...
[INFO] Copy webapp webResources to src/jenkinsci/sshd-plugin/target/sshd
[INFO] Assembling webapp sshd in src/jenkinsci/sshd-plugin/target/sshd
[WARNING] Bundling transitive dependency self-signed-cert-generator-1.0.0.jar (via instance-identity)
[INFO] Bundling direct dependency eddsa-0.3.0.jar
[WARNING] Bundling transitive dependency sshd-common-2.8.0.jar (via sshd-core)
[INFO] Bundling direct dependency sshd-core-2.8.0.jar
[INFO] Bundling direct dependency instance-identity-2.2.jar
[INFO] Generating hpi src/jenkinsci/sshd-plugin/target/sshd.hpi
[INFO] Building jar: src/jenkinsci/sshd-plugin/target/sshd.hpi
```

CC @kuisathaverat