### PR TITLE
Do not bundle a copy of `instance-identity`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,20 +32,7 @@
     <revision>3</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.289.1</jenkins.version>
-    <java.level>8</java.level>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.277.x</artifactId>
-        <version>961.vf0c9f6f59827</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -72,7 +59,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>2.2</version> <!-- We use the module for the moment -->
+      <scope>provided</scope> <!-- TODO pending JEP-230 we use the module -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
#38 was incorrect. Noticed when trying to test https://github.com/jenkinsci/jenkins/pull/6585 that even when `instance-identity` is not enabled as a plugin, `InstanceIdentityRSAProvider` gets loaded from `plugins/sshd/WEB-INF/lib/instance-identity-2.2.jar`.
