### PR TITLE
Forgotten `/project/url`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>${revision}.${changelist}</version>
   <packaging>hpi</packaging>
   <name>SSH server</name>
-  <description>Adds SSH server functionality to Jenkins, exposing CLI commands through it</description>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>


### PR DESCRIPTION
Noticed that `/pluginManager/installed` showed this plugin without a hyperlink.