### PR TITLE
Use `instance-identity` from BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.361.x</artifactId>
-        <version>1763.v092b_8980a_f5e</version>
+        <version>1775.vf0577a_a_01778</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -61,7 +61,6 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>142.v04572ca_5b_265</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
No need for an explicit version now that this dependency is in the managed set.