### PR TITLE
Remove dead store to set the keyPairProvider

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -159,8 +159,6 @@ public class SSHD extends GlobalConfiguration {
         sshd.setKeyExchangeFactories(filterKeyExchanges(sshd.getKeyExchangeFactories()));
         sshd.setMacFactories(filterMacs(sshd.getMacFactories()));
         sshd.setPort(port);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
-
         sshd.setKeyPairProvider(new AbstractKeyPairProvider() {
             @Override
             public Iterable<KeyPair> loadKeys(SessionContext session) throws IOException, GeneralSecurityException {


### PR DESCRIPTION
## Remove dead store to set the keyPairProvider

No need to set the keyPairProvider to a default value then immediately set it to a different value.

Storing once should be enough.

Detect as the only production use of `SimpleGeneratorHostKeyProvider` in the Jenkins code base while investigating for https://github.com/jenkinsci/jenkins/pull/7623

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
