### PR TITLE
Remove unused Java imports

### DIFF
--- a/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
+++ b/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java
@@ -34,7 +34,6 @@ import org.apache.sshd.common.mac.Mac;
 import org.apache.sshd.common.session.SessionContext;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.UserAuthFactory;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.kohsuke.stapler.StaplerRequest;
 

--- a/src/test/java/org/jenkinsci/main/modules/cli/auth/ssh/CLITest.java
+++ b/src/test/java/org/jenkinsci/main/modules/cli/auth/ssh/CLITest.java
@@ -74,7 +74,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;


### PR DESCRIPTION
## Remove unused Java imports

Unused Java imports can be a distraction when reviewing changes.  Remove the unused imports.  Does not implement the automation to prevent future unused imports.

https://github.com/jenkinsci/sshd-plugin/pull/119#issuecomment-1449060893 is resolved by this change

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
